### PR TITLE
Hacky fix for java and kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: "com.gradle.plugin-publish"
+apply plugin: "maven-publish"
 
 if (project.hasProperty("signing.keyId")) {
     apply plugin: 'signing'
@@ -46,6 +47,18 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
     classifier = 'sources'
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifact sourcesJar {
+                classifier "sources"
+            }
+        }
+    }
+}
+
 
 artifacts {
     archives jar


### PR DESCRIPTION
Do enhancement after classes

This solves the issue with multiple programming languages in the same
Project by moving the enhancement step.

(Gradle tasks within quotes)

Previously:
1. "processResources"
2. Enhance resources
3. "compileKotlin"
4. Enhance Kotlin code
   - Here it will fail if not all dependencies are in Kotlin
5. "compileJava"
6. Enhance Java code
   - Here it will fail if not all dependencies are in Java
7. "classes"
8. Enhance classes

Now:
1. "processResources"
2. "compileKotlin"
3. "compileJava"
4. "classes"
5. Enhance everything
