### PR TITLE
Fix configuration cache compatibility and enhancement ordering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,15 @@
 plugins {
   id 'groovy'
-  id 'java-gradle-plugin'
-  id 'com.gradle.plugin-publish' version '0.11.0'
-  id 'maven-publish'
+  id 'com.gradle.plugin-publish' version '2.1.1'
 }
 
 group 'io.ebean'
-version '16.3.0'
+version '17.4.0'
 
-sourceCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenLocal()
@@ -16,20 +17,28 @@ repositories {
 }
 
 dependencies {
-  implementation 'io.ebean:ebean-agent:16.3.0'
+  implementation 'io.ebean:ebean-agent:17.4.0'
   implementation gradleApi()
   implementation localGroovy()
+  testImplementation gradleTestKit()
+  testImplementation 'junit:junit:4.13.2'
 }
 
-pluginBundle {
+gradlePlugin {
   website = 'https://ebean-orm.github.io/docs/tooling/gradle'
   vcsUrl = 'https://github.com/ebean-orm-tools/ebean-gradle-plugin'
-  description = 'Ebean ORM enhancement plugin'
-  tags = ['Ebean', 'ORM', 'JPA']
   plugins {
     ebeanPlugin {
       id = 'io.ebean'
+      implementationClass = 'io.ebean.gradle.EnhancePlugin'
       displayName = 'Ebean plugin'
+      description = 'Ebean ORM enhancement plugin'
+      tags.set(['Ebean', 'ORM', 'JPA'])
+      compatibility(it) {
+        features {
+          configurationCache = true
+        }
+      }
     }
   }
 }

--- a/docs/configuration-cache-fix.md
+++ b/docs/configuration-cache-fix.md
@@ -1,0 +1,62 @@
+# Configuration-cache fix
+
+## Summary
+
+This change makes the Ebean Gradle plugin compatible with Gradle's configuration cache and preserves enhancement for packaged outputs such as `jar` and `testFixturesJar`.
+
+## Root cause
+
+The original implementation attached Groovy closures directly to existing tasks:
+
+- `task.doLast { ... enhanceTaskOutputs(project, ...) }`
+- `testTask.doFirst { ... createClassPath(project, ...) }`
+
+Those closures captured `Project` and other mutable Gradle model objects at execution time. With configuration cache enabled, Gradle attempted to serialize those task actions and failed because they retained `DefaultProject` references.
+
+## What changed
+
+### Dedicated enhancement task
+
+Enhancement now runs in a dedicated `EbeanEnhanceTask` instead of ad-hoc `doFirst`/`doLast` closures.
+
+The task declares:
+
+- enhancement classpath as `@Classpath`
+- compiled class directories as `@InputFiles`
+- debug level as `@Input`
+
+This gives Gradle a configuration-cache-safe model of the work to run.
+
+### Task graph wiring
+
+Instead of enhancing classes as a late finalizer, the plugin now registers explicit enhancement tasks for:
+
+- `main`
+- `test`
+- `testFixtures` (when present)
+
+and wires consumers to depend on enhancement before they package or execute those classes.
+
+That is important for `testFixturesJar`, because packaging before enhancement leaves the jar with stale, unenhanced bytecode.
+
+### Publishing metadata modernization
+
+The build keeps Gradle Plugin Portal publishing support, but updates it to the modern `com.gradle.plugin-publish` 2.x configuration style:
+
+- `pluginBundle` metadata moved into `gradlePlugin`
+- plugin portal compatibility metadata declares `configurationCache = true`
+
+This keeps publishing support in place while matching current portal guidance.
+
+## Validation
+
+The patch was validated in a consumer build with Gradle 9.4.1 by checking that:
+
+1. `test --configuration-cache` stores the configuration cache successfully
+2. a second `test --configuration-cache` run reuses the cache
+3. `testFixturesJar` contains an enhanced entity class, not stale pre-enhancement bytecode
+
+## Notes
+
+- The local consumer validation that motivated this change used Ebean `17.4.0`, so the branch aligns the embedded `ebean-agent` dependency to `17.4.0` as well.
+- If maintainers prefer to manage the published plugin version separately, the structural fix in `EnhancePlugin`/`EbeanEnhanceTask` can be applied independently from release-version decisions.

--- a/docs/configuration-cache-fix.md
+++ b/docs/configuration-cache-fix.md
@@ -39,6 +39,21 @@ and wires consumers to depend on enhancement before they package or execute thos
 
 That is important for `testFixturesJar`, because packaging before enhancement leaves the jar with stale, unenhanced bytecode.
 
+### Enhanced outputs for downstream project consumers
+
+A second issue remained after the initial configuration-cache fix: enhancement still rewrote raw compiler output directories in place.
+
+That allowed downstream project dependencies to snapshot or package those raw class directories while enhancement was mutating them, which could surface as intermittent `No such file or directory` failures in Gradle/Kotlin transforms.
+
+The plugin now:
+
+- merges raw compiler outputs into a dedicated enhanced output directory per source set
+- exposes that enhanced directory as the source set's consumable classes output
+- keeps raw compile directories internal
+- excludes raw compile directories from jar packaging
+
+This removes the producer/consumer race by ensuring downstream consumers and packaging tasks only read stable enhanced outputs.
+
 ### Publishing metadata modernization
 
 The build keeps Gradle Plugin Portal publishing support, but updates it to the modern `com.gradle.plugin-publish` 2.x configuration style:
@@ -55,6 +70,7 @@ The patch was validated in a consumer build with Gradle 9.4.1 by checking that:
 1. `test --configuration-cache` stores the configuration cache successfully
 2. a second `test --configuration-cache` run reuses the cache
 3. `testFixturesJar` contains an enhanced entity class, not stale pre-enhancement bytecode
+4. downstream project dependencies resolve enhanced producer classes instead of raw compile outputs
 
 ## Notes
 

--- a/src/main/groovy/io/ebean/gradle/EbeanEnhanceTask.groovy
+++ b/src/main/groovy/io/ebean/gradle/EbeanEnhanceTask.groovy
@@ -1,0 +1,41 @@
+package io.ebean.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = 'Enhances compiled classes in place')
+abstract class EbeanEnhanceTask extends DefaultTask {
+
+  @Classpath
+  abstract ConfigurableFileCollection getClasspathFiles()
+
+  @InputFiles
+  @SkipWhenEmpty
+  @PathSensitive(PathSensitivity.RELATIVE)
+  abstract ConfigurableFileCollection getClassesDirs()
+
+  @Input
+  abstract Property<Integer> getDebugLevel()
+
+  @TaskAction
+  void enhanceClasses() {
+    List<URL> baseUrls = classpathFiles.files.collect { it.toURI().toURL() }
+    ClassLoader contextLoader = Thread.currentThread().getContextClassLoader()
+    EnhancePluginExtension params = new EnhancePluginExtension(debugLevel: debugLevel.get())
+
+    classesDirs.files.findAll { it.exists() }.each { outputDir ->
+      List<URL> urls = new ArrayList<>(baseUrls)
+      urls.add(outputDir.toURI().toURL())
+      new EbeanEnhancer(outputDir.toPath(), urls.toArray(new URL[0]), contextLoader, params).enhance()
+    }
+  }
+}

--- a/src/main/groovy/io/ebean/gradle/EbeanEnhanceTask.groovy
+++ b/src/main/groovy/io/ebean/gradle/EbeanEnhanceTask.groovy
@@ -2,17 +2,22 @@ package io.ebean.gradle
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
-@DisableCachingByDefault(because = 'Enhances compiled classes in place')
+import javax.inject.Inject
+
+@DisableCachingByDefault(because = 'Copies and enhances compiled classes into dedicated output directories')
 abstract class EbeanEnhanceTask extends DefaultTask {
 
   @Classpath
@@ -21,21 +26,41 @@ abstract class EbeanEnhanceTask extends DefaultTask {
   @InputFiles
   @SkipWhenEmpty
   @PathSensitive(PathSensitivity.RELATIVE)
-  abstract ConfigurableFileCollection getClassesDirs()
+  abstract ConfigurableFileCollection getRawClassesDirs()
+
+  @OutputDirectory
+  abstract DirectoryProperty getEnhancedClassesDir()
 
   @Input
   abstract Property<Integer> getDebugLevel()
 
+  @Inject
+  abstract FileSystemOperations getFileSystemOperations()
+
   @TaskAction
   void enhanceClasses() {
+    List<File> rawDirs = rawClassesDirs.files.sort { it.absolutePath }
+    File enhancedDir = enhancedClassesDir.get().asFile
+
+    fileSystemOperations.delete {
+      delete(enhancedDir)
+    }
+
+    rawDirs.findAll { it.exists() }.each { File rawDir ->
+      fileSystemOperations.copy {
+        from(rawDir)
+        into(enhancedDir)
+      }
+    }
+
     List<URL> baseUrls = classpathFiles.files.collect { it.toURI().toURL() }
+    List<File> existingEnhancedDirs = enhancedDir.exists() ? [enhancedDir] : []
+    baseUrls.add(enhancedDir.toURI().toURL())
     ClassLoader contextLoader = Thread.currentThread().getContextClassLoader()
     EnhancePluginExtension params = new EnhancePluginExtension(debugLevel: debugLevel.get())
 
-    classesDirs.files.findAll { it.exists() }.each { outputDir ->
-      List<URL> urls = new ArrayList<>(baseUrls)
-      urls.add(outputDir.toURI().toURL())
-      new EbeanEnhancer(outputDir.toPath(), urls.toArray(new URL[0]), contextLoader, params).enhance()
+    existingEnhancedDirs.each { outputDir ->
+      new EbeanEnhancer(outputDir.toPath(), baseUrls.toArray(new URL[0]), contextLoader, params).enhance()
     }
   }
 }

--- a/src/main/groovy/io/ebean/gradle/EnhancePlugin.groovy
+++ b/src/main/groovy/io/ebean/gradle/EnhancePlugin.groovy
@@ -2,10 +2,12 @@ package io.ebean.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.jvm.tasks.Jar
 import org.gradle.api.tasks.testing.Test
 
 class EnhancePlugin implements Plugin<Project> {
@@ -39,21 +41,38 @@ class EnhancePlugin implements Plugin<Project> {
       return
     }
 
+    List<File> rawClassDirs = sourceSet.output.classesDirs.files.sort { it.absolutePath }
+    if (rawClassDirs.isEmpty()) {
+      return
+    }
+
+    File enhancedClassDir = new File(project.buildDir, "ebean-enhanced/${sourceSet.name}")
+
     def enhanceTaskName = sourceSet.name == SourceSet.MAIN_SOURCE_SET_NAME ? 'ebeanEnhance' : "ebeanEnhance${sourceSet.name.capitalize()}"
     def enhanceTask = project.tasks.register(enhanceTaskName, EbeanEnhanceTask) { task ->
       task.group = 'ebean'
       task.description = "Enhances Ebean classes for the ${sourceSet.name} source set."
       task.debugLevel.set(params.debugLevel)
       task.classpathFiles.from(sourceSet.compileClasspath)
-      task.classpathFiles.from(sourceSet.output)
-      task.classesDirs.from(sourceSet.output.classesDirs)
+      if (sourceSet.output.resourcesDir != null) {
+        task.classpathFiles.from(sourceSet.output.resourcesDir)
+      }
+      task.rawClassesDirs.from(rawClassDirs)
+      task.enhancedClassesDir.set(enhancedClassDir)
       task.dependsOn(lifecycleTask)
     }
 
+    ConfigurableFileCollection classesDirs = sourceSet.output.classesDirs as ConfigurableFileCollection
+    classesDirs.setFrom(enhancedClassDir)
+    classesDirs.builtBy(enhanceTask)
+
     def jarTaskName = sourceSet.name == SourceSet.MAIN_SOURCE_SET_NAME ? 'jar' : sourceSet.name == 'testFixtures' ? 'testFixturesJar' : null
     if (jarTaskName != null) {
-      project.tasks.matching { it.name == jarTaskName }.configureEach {
+      project.tasks.withType(Jar).matching { it.name == jarTaskName }.configureEach {
         dependsOn(enhanceTask)
+        exclude { details ->
+          rawClassDirs.any { rawDir -> details.file.toPath().startsWith(rawDir.toPath()) }
+        }
       }
     }
 

--- a/src/main/groovy/io/ebean/gradle/EnhancePlugin.groovy
+++ b/src/main/groovy/io/ebean/gradle/EnhancePlugin.groovy
@@ -2,177 +2,63 @@ package io.ebean.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.UnknownTaskException
-import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.compile.AbstractCompile
-
-import java.nio.file.Path
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.testing.Test
 
 class EnhancePlugin implements Plugin<Project> {
 
   private final Logger logger = Logging.getLogger(EnhancePlugin.class)
 
-  private static def supportedCompilerTasks = [
-    'processResources',
-    'compileJava',
-    'compileKotlin',
-    'compileGroovy',
-    'compileScala',
-    'compileKotlinAfterJava',
-    'copyMainKotlinClasses',
-    'classes',
-    'testClasses',
-    'compileTestJava',
-    'compileTestKotlin',
-    'compileTestGroovy',
-    'compileTestScala',
-    'compileTestFixturesJava',
-    'compileTestFixturesKotlin',
-    'compileTestFixturesGroovy',
-    'compileTestFixturesScala',
-  ]
-
-  /**
-   * Output directories containing classes we want to run enhancement on.
-   */
-  private def outputDirs = new HashMap<Project, Set<File>>().withDefault { [] }
-
-  /**
-   * Test output directories containing classes we want to run enhancement on.
-   */
-  private def testOutputDirs = new HashMap<Project, Set<File>>().withDefault { [] }
-
   void apply(Project project) {
-    def params = project.extensions.create("ebean", EnhancePluginExtension)
+    EnhancePluginExtension params = project.extensions.create('ebean', EnhancePluginExtension)
 
-    // delay the registration of the various compile task.doLast hooks
     project.afterEvaluate({
-
-      EnhancePluginExtension extension = project.extensions.findByType(EnhancePluginExtension)
       logger.info("EnhancePlugin apply")
 
-      def tasks = project.tasks
-      initializeOutputDirs(project)
-      // processResources task must be run before compileJava so ebean.mf to be in place. Same is valid for tests
-      tasks.findByName("compileJava").mustRunAfter(tasks.findByName("processResources"))
-      tasks.findByName("compileTestJava").mustRunAfter(tasks.findByName("processTestResources"))
-      supportedCompilerTasks.each { compileTask ->
-        tryHookCompilerTask(tasks, compileTask, project, params)
+      SourceSetContainer sourceSets = project.extensions.findByName('sourceSets') as SourceSetContainer
+      if (sourceSets == null) {
+        return
       }
 
-      def testTask = project.tasks.getByName('test')
-      testTask.doFirst {
-        logger.debug("enhancement prior to running tests")
-
-        URL[] classpathUrls = toUrlArray(createClassPath(project, 'compileClasspath'))
-        enhanceDirectory(extension, "$project.buildDir/classes/main/", classpathUrls)
-        enhanceDirectory(extension, "$project.buildDir/kotlin-classes/main/", classpathUrls)
-
-        URL[] testClasspathUrls = toUrlArray(createClassPath(project, 'testCompileClasspath'))
-        enhanceDirectory(extension, "$project.buildDir/classes/test/", testClasspathUrls)
-      }
+      registerEnhanceTask(project, sourceSets.findByName(SourceSet.MAIN_SOURCE_SET_NAME), params)
+      registerEnhanceTask(project, sourceSets.findByName(SourceSet.TEST_SOURCE_SET_NAME), params)
+      registerEnhanceTask(project, sourceSets.findByName('testFixtures'), params)
     })
   }
 
-  private static URL[] toUrlArray(List<URL> urls) {
-    return urls.toArray(new URL[urls.size()])
-  }
-
-  /**
-   * Fetch the output directories, containing the classes to enhance, from the project's sources set.
-   */
-  private void initializeOutputDirs(Project project) {
-    project.sourceSets.each { sourceSet ->
-      Set<File> files = sourceSet.output.classesDirs.files as Set<File>
-      testOutputDirs[project] += files.findAll {
-        it.name.contains("test")
-      }
-      outputDirs[project] += files.findAll {
-        it.name.contains("main")
-      }
-    }
-    logger.debug("Test output dirs: $testOutputDirs")
-    logger.debug("Main output dirs: $outputDirs")
-  }
-
-  private void tryHookCompilerTask(TaskContainer tasks, String taskName, Project project, EnhancePluginExtension params) {
-    try {
-      def task = tasks.getByName(taskName)
-      task.doLast({ Task completedTask ->
-        enhanceTaskOutputs(project, params, completedTask)
-      })
-    } catch (UnknownTaskException e) {
-      logger.debug("Ignore as compiler task is not activated " + e.message)
-    }
-  }
-
-  /**
-   * Perform the enhancement for the classes and testClasses tasks only (otherwise skip).
-   */
-  private void enhanceTaskOutputs(Project project, EnhancePluginExtension params, Task task) {
-    Set<File> projectOutputDirs = new HashSet<>()
-    if (task instanceof AbstractCompile || isKotlinCompileTask(task.name)) {
-      projectOutputDirs.addAll(task.outputs.files)
-    } else {
+  private void registerEnhanceTask(Project project, SourceSet sourceSet, EnhancePluginExtension params) {
+    if (sourceSet == null) {
       return
     }
 
-    logger.debug("perform enhancement for task: $task")
-    List<URL> urls = createClassPath(project, "testCompileClasspath")
-    def cxtLoader = Thread.currentThread().getContextClassLoader()
-
-    projectOutputDirs.each { urls.add(it.toURI().toURL()) }
-    projectOutputDirs.each { outputDir ->
-      // also add outputDir to the classpath
-      Path output = outputDir.toPath()
-      urls.add(output.toUri().toURL())
-      new EbeanEnhancer(output, toUrlArray(urls), cxtLoader, params).enhance()
-    }
-  }
-
-  private static void enhanceDirectory(EnhancePluginExtension params, String outputDir, URL[] classpathUrls) {
-    File outDir = new File(outputDir)
-    if (!outDir.exists()) {
+    def lifecycleTask = project.tasks.findByName(sourceSet.classesTaskName)
+    if (lifecycleTask == null) {
       return
     }
 
-    def cxtLoader = Thread.currentThread().getContextClassLoader()
-    new EbeanEnhancer(outDir.toPath(), classpathUrls, cxtLoader, params).enhance()
-  }
-
-
-  private static List<URL> createClassPath(Project project, String classpathName) {
-    Set<File> compCP = project.configurations.getByName(classpathName).resolve()
-    List<URL> urls = compCP.collect { it.toURI().toURL() }
-
-    FileCollection outDirs = project.sourceSets.main.output.classesDirs
-    outDirs.each { outputDir ->
-      addToClassPath(urls, outputDir)
+    def enhanceTaskName = sourceSet.name == SourceSet.MAIN_SOURCE_SET_NAME ? 'ebeanEnhance' : "ebeanEnhance${sourceSet.name.capitalize()}"
+    def enhanceTask = project.tasks.register(enhanceTaskName, EbeanEnhanceTask) { task ->
+      task.group = 'ebean'
+      task.description = "Enhances Ebean classes for the ${sourceSet.name} source set."
+      task.debugLevel.set(params.debugLevel)
+      task.classpathFiles.from(sourceSet.compileClasspath)
+      task.classpathFiles.from(sourceSet.output)
+      task.classesDirs.from(sourceSet.output.classesDirs)
+      task.dependsOn(lifecycleTask)
     }
 
-    File resMain = new File(project.buildDir, "resources/main")
-    if (resMain.exists() && resMain.isDirectory()) {
-      addToClassPath(urls, resMain)
+    def jarTaskName = sourceSet.name == SourceSet.MAIN_SOURCE_SET_NAME ? 'jar' : sourceSet.name == 'testFixtures' ? 'testFixturesJar' : null
+    if (jarTaskName != null) {
+      project.tasks.matching { it.name == jarTaskName }.configureEach {
+        dependsOn(enhanceTask)
+      }
     }
 
-    File kotlinMain = new File(project.buildDir, "kotlin-classes/main")
-    if (kotlinMain.exists() && kotlinMain.isDirectory()) {
-      addToClassPath(urls, kotlinMain)
+    project.tasks.withType(Test).configureEach {
+      dependsOn(enhanceTask)
     }
-    return urls
-  }
-
-  static void addToClassPath(List<URL> urls, File file) {
-    urls.add(file.toURI().toURL())
-  }
-
-  static boolean isKotlinCompileTask(String taskName) {
-    return 'compileKotlin'.equalsIgnoreCase(taskName) ||
-      'compileTestKotlin'.equalsIgnoreCase(taskName) ||
-      'compileTestFixturesKotlin'.equalsIgnoreCase(taskName)
   }
 }

--- a/src/main/resources/META-INF/gradle-plugins/io.ebean.properties
+++ b/src/main/resources/META-INF/gradle-plugins/io.ebean.properties
@@ -1,1 +1,0 @@
-implementation-class=io.ebean.gradle.EnhancePlugin

--- a/src/test/groovy/io/ebean/gradle/EnhancePluginFunctionalTest.groovy
+++ b/src/test/groovy/io/ebean/gradle/EnhancePluginFunctionalTest.groovy
@@ -39,6 +39,15 @@ class EnhancePluginFunctionalTest {
     assertTrue(result.output.contains('Verified enhancement in test fixtures jar'))
   }
 
+  @Test
+  void exposesEnhancedProducerClassesToProjectDependencyConsumers() {
+    writeMultiProjectDependencyBuild()
+
+    def result = runner(':consumer:verifyProducerDependencyIsEnhanced', '--stacktrace').build()
+    assertEquals(SUCCESS, result.task(':consumer:verifyProducerDependencyIsEnhanced').outcome)
+    assertTrue(result.output.contains('Verified enhanced producer dependency'))
+  }
+
   private GradleRunner runner(String... arguments) {
     GradleRunner.create()
       .withProjectDir(testProjectDir)
@@ -124,6 +133,84 @@ public class SampleTest {
   @Test
   public void passes() {
   }
+}
+''')
+  }
+
+  private void writeMultiProjectDependencyBuild() {
+    testProjectDir = File.createTempDir('ebean-gradle-plugin', 'functional-test')
+    new File(testProjectDir, 'producer').mkdirs()
+    new File(testProjectDir, 'consumer').mkdirs()
+
+    new File(testProjectDir, 'settings.gradle') << '''
+rootProject.name = 'sample'
+include 'producer', 'consumer'
+'''.trim() + '\n'
+
+    new File(testProjectDir, 'build.gradle') << '''
+allprojects {
+  repositories {
+    mavenCentral()
+  }
+}
+'''.trim() + '\n'
+
+    new File(testProjectDir, 'producer/build.gradle') << '''
+plugins {
+  id 'java-library'
+  id 'io.ebean'
+}
+
+dependencies {
+  api 'io.ebean:ebean:17.4.0'
+  api 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+}
+'''.trim() + '\n'
+
+    new File(testProjectDir, 'consumer/build.gradle') << '''
+plugins {
+  id 'java-library'
+}
+
+dependencies {
+  implementation project(':producer')
+}
+
+tasks.register('verifyProducerDependencyIsEnhanced') {
+  inputs.files(sourceSets.main.compileClasspath)
+  doLast {
+    def urls = sourceSets.main.compileClasspath.files.collect { it.toURI().toURL() } as URL[]
+    URLClassLoader loader = new URLClassLoader(urls, (ClassLoader) null)
+    try {
+      def entityClass = loader.loadClass('sample.ProducerEntity')
+      def entityBeanType = loader.loadClass('io.ebean.bean.EntityBean')
+      assert entityBeanType.isAssignableFrom(entityClass)
+      println 'Verified enhanced producer dependency'
+    } finally {
+      loader.close()
+    }
+  }
+}
+'''.trim() + '\n'
+
+    writeSource('producer/src/main/java/sample/ProducerEntity.java', '''
+package sample;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class ProducerEntity {
+  @Id
+  Long id;
+}
+''')
+
+    writeSource('consumer/src/main/java/sample/ConsumerType.java', '''
+package sample;
+
+public class ConsumerType {
+  ProducerEntity producerEntity;
 }
 ''')
   }

--- a/src/test/groovy/io/ebean/gradle/EnhancePluginFunctionalTest.groovy
+++ b/src/test/groovy/io/ebean/gradle/EnhancePluginFunctionalTest.groovy
@@ -1,0 +1,136 @@
+package io.ebean.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.After
+import org.junit.Test
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+class EnhancePluginFunctionalTest {
+
+  private File testProjectDir
+
+  @After
+  void cleanup() {
+    if (testProjectDir != null) {
+      testProjectDir.deleteDir()
+    }
+  }
+
+  @Test
+  void storesAndReusesConfigurationCacheForTestTask() {
+    writeProject()
+
+    def first = runner('test', '--configuration-cache', '--stacktrace').build()
+    assertTrue(first.output.contains('Configuration cache entry stored'))
+
+    def second = runner('test', '--configuration-cache', '--stacktrace').build()
+    assertTrue(second.output.contains('Reusing configuration cache.'))
+  }
+
+  @Test
+  void enhancesTestFixturesBeforePackagingThem() {
+    writeProject()
+
+    def result = runner('verifyEnhancedTestFixturesJar', '--stacktrace').build()
+    assertEquals(SUCCESS, result.task(':verifyEnhancedTestFixturesJar').outcome)
+    assertTrue(result.output.contains('Verified enhancement in test fixtures jar'))
+  }
+
+  private GradleRunner runner(String... arguments) {
+    GradleRunner.create()
+      .withProjectDir(testProjectDir)
+      .withArguments(arguments)
+      .withPluginClasspath()
+      .withGradleVersion('9.4.1')
+  }
+
+  private void writeProject() {
+    testProjectDir = File.createTempDir('ebean-gradle-plugin', 'functional-test')
+
+    new File(testProjectDir, 'settings.gradle') << "rootProject.name = 'sample'\n"
+
+    new File(testProjectDir, 'build.gradle') << '''
+plugins {
+  id 'java-library'
+  id 'java-test-fixtures'
+  id 'io.ebean'
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'io.ebean:ebean:17.4.0'
+  implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+  testFixturesImplementation 'io.ebean:ebean:17.4.0'
+  testFixturesImplementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+  testImplementation 'junit:junit:4.13.2'
+}
+
+tasks.register('verifyEnhancedTestFixturesJar') {
+  dependsOn tasks.named('testFixturesJar')
+  doLast {
+    def jarFile = tasks.named('testFixturesJar').get().archiveFile.get().asFile
+    def urls = (configurations.testFixturesRuntimeClasspath.files + [jarFile]).collect { it.toURI().toURL() } as URL[]
+    URLClassLoader loader = new URLClassLoader(urls, (ClassLoader) null)
+    try {
+      def clazz = loader.loadClass('sample.FixtureEntity')
+      def entityBeanType = loader.loadClass('io.ebean.bean.EntityBean')
+      assert entityBeanType.isAssignableFrom(clazz)
+      println 'Verified enhancement in test fixtures jar'
+    } finally {
+      loader.close()
+    }
+  }
+}
+'''
+
+    writeSource('src/main/java/sample/MainEntity.java', '''
+package sample;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class MainEntity {
+  @Id
+  Long id;
+}
+''')
+
+    writeSource('src/testFixtures/java/sample/FixtureEntity.java', '''
+package sample;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class FixtureEntity {
+  @Id
+  Long id;
+}
+''')
+
+    writeSource('src/test/java/sample/SampleTest.java', '''
+package sample;
+
+import org.junit.Test;
+
+public class SampleTest {
+  @Test
+  public void passes() {
+  }
+}
+''')
+  }
+
+  private void writeSource(String relativePath, String content) {
+    File file = new File(testProjectDir, relativePath)
+    file.parentFile.mkdirs()
+    file.text = content.trim() + '\n'
+  }
+}


### PR DESCRIPTION
## Summary

  This PR makes the plugin compatible with Gradle's configuration cache and fixes enhancement ordering so packaged outputs (especially testFixturesJar) contain enhanced bytecode instead of stale pre-enhancement classes.

## Root cause

  The plugin currently attaches Groovy closures directly to existing tasks:

-  `task.doLast { ... }`
-  `testTask.doFirst { ... }`

  Those closures capture `Project` and other mutable Gradle model objects at execution time. With configuration cache enabled, Gradle tries to serialize those task actions and fails because they retain `DefaultProject` references.

  There was also an ordering issue: enhancement could run too late for packaged outputs, which meant jars could be created from unenhanced classes.

## What changed

### Configuration-cache-safe enhancement
-  Introduced a dedicated `EbeanEnhanceTask`
-  Declared its inputs explicitly (`@Classpath, @InputFiles, @Input`)
-  Moved enhancement work out of ad-hoc `doFirst` / `doLast` closures

### Correct task ordering
- Registered enhancement tasks
- Wired consuming tasks to depend on enhancement before packaging/execution

This ensures jars and test execution see enhanced classes, not stale outputs.

### Publishing metadata modernization
-  Upgraded to modern `com.gradle.plugin-publish`
-  Moved old `pluginBundle` metadata into `gradlePlugin`
-  Declared configuration-cache compatibility in plugin metadata
-  Removed the checked-in plugin descriptor file that duplicated the descriptor generated by `gradlePlugin`

### Functional test coverage
Added TestKit functional tests that verify:

1. `test --configuration-cache` stores the configuration cache
2. a second run reuses the configuration cache
3. `testFixturesJar` contains enhanced entity classes

## Notes

- This branch also aligns the embedded ebean-agent dependency to 17.4.0, matching the consumer build used to reproduce and verify the issue.

## Full disclosure

I'm an experienced kotlin developer, but I have no experience writing gradle plugins. I used GPT-5.4 to create this fix and don't fully understand the details, but I can confirm that it does work in our ebean-heavy 100k LOC project. I would completely understand if you don't want to merge this PR as is (or at all), but I still believe it can be useful as a base for a manual fix by someone who knows what they're doing ;)