### PR TITLE
Fix #42 - Support explicitly setting sourceSets to enhance

### DIFF
--- a/src/main/groovy/io/ebean/gradle/EnhancePlugin.groovy
+++ b/src/main/groovy/io/ebean/gradle/EnhancePlugin.groovy
@@ -25,9 +25,9 @@ class EnhancePlugin implements Plugin<Project> {
         return
       }
 
-      registerEnhanceTask(project, sourceSets.findByName(SourceSet.MAIN_SOURCE_SET_NAME), params)
-      registerEnhanceTask(project, sourceSets.findByName(SourceSet.TEST_SOURCE_SET_NAME), params)
-      registerEnhanceTask(project, sourceSets.findByName('testFixtures'), params)
+      for (String sourceSetName : params.enhanceSourceSets) {
+        registerEnhanceTask(project, sourceSets.findByName(sourceSetName), params)
+      }
     })
   }
 

--- a/src/main/groovy/io/ebean/gradle/EnhancePluginExtension.groovy
+++ b/src/main/groovy/io/ebean/gradle/EnhancePluginExtension.groovy
@@ -24,4 +24,13 @@ class EnhancePluginExtension {
    * querybean-generator version for use when addKapt is true.
    */
   String generatorVersion = '11.36.1'
+
+  /**
+   * Source sets to apply enhancement to. Defaults to main, test, and testFixtures.
+   * <p>
+   * Override to limit enhancement to specific source sets. For example, set to
+   * {@code ['test']} to only enhance the test source set (e.g. when ebean is a
+   * test-only dependency).
+   */
+  List<String> enhanceSourceSets = ['main', 'test', 'testFixtures']
 }


### PR DESCRIPTION
Currently, the plugin hardcodes enhancement for main, test, and testFixtures with no way to opt out — causing unnecessary overhead when ebean is only needed for some source sets.

Supports setting explicitly the sourceSets for this plugin to enhance.

Changes made:

EnhancePluginExtension.groovy — added enhanceSourceSets property:

 List<String> enhanceSourceSets = ['main', 'test', 'testFixtures']

Defaults preserve current behaviour. Users can override, e.g.:

```
 ebean {
   enhanceSourceSets = ['test']  // only enhance test source set
 }
```